### PR TITLE
Add Overlay color of 30% black on demo gif

### DIFF
--- a/src/components/contact/Contact.scss
+++ b/src/components/contact/Contact.scss
@@ -1,9 +1,11 @@
 @use '../../styles/breakpoint.scss';
 
+$demo-gif-overlay-color: rgba(0, 0, 0, 0.3);
+
 #demo-gif-container {
   height: 150px;
   overflow: hidden;
-  background-image: url('../../assets/background.gif');
+  background-image: linear-gradient(0deg, $demo-gif-overlay-color, $demo-gif-overlay-color), url('../../assets/background.gif');
   background-size: cover;
   background-position: center;
   text-align: center;


### PR DESCRIPTION
because the demo gif had a #fff color which clashes with the contact links in front of the demo gif

Now:
![image](https://github.com/iamfranco/iamfranco.github.io/assets/23167776/40396d49-947c-49f5-a505-3808aab9f54a)
